### PR TITLE
Support limit orders

### DIFF
--- a/src/data_sources/revolut/stock/csv_parser.py
+++ b/src/data_sources/revolut/stock/csv_parser.py
@@ -11,7 +11,9 @@ from domain.transactions import Transaction
 class StockCsvParser(CsvParser):
     OPERATIONS = {
         "BUY - MARKET": OperationType.BUY,
+        "BUY - LIMIT": OperationType.BUY,
         "SELL - MARKET": OperationType.SELL,
+        "SELL - LIMIT": OperationType.SELL,
         "DIVIDEND": OperationType.DIVIDEND,
         "CUSTODY FEE": OperationType.CUSTODY_FEE,
         "STOCK SPLIT": OperationType.STOCK_SPLIT,


### PR DESCRIPTION
It crashes failing to find a buy transaction when analysing a sell transaction without this change.

Note that that further changes may be needed to support all transaction types. Maybe it should check for prefix like `BUY` or `SELL` without regarding for specific mechanism?